### PR TITLE
tweak to support cygwin

### DIFF
--- a/winpcapy/winpcapy_types.py
+++ b/winpcapy/winpcapy_types.py
@@ -17,7 +17,7 @@ WIN32=False
 HAVE_REMOTE=False
 
 
-if sys.platform.startswith('win'):
+if 'win' in sys.platform:
     WIN32=True
     HAVE_REMOTE=True
 


### PR DESCRIPTION
cygwin systems return 'cygwin' for sys.platform, which does not start with 'win', and the test was failing